### PR TITLE
Update grants.yml

### DIFF
--- a/tasks/grants.yml
+++ b/tasks/grants.yml
@@ -5,8 +5,8 @@
   mysql_user: user={{ galera_conf['dbusers']['docker']['username'] }} host={{ galera_conf['dbusers']['docker']['host'] }}  password={{ galera_conf['dbusers']['docker']['password'] }} priv=*.*:"all privileges"
 
 - name: Add xtrabackup database user (for Galera SST)
-  mysql_user: user={{ galera_conf['dbusers']['xtrabackup']['username'] }} host="localhost" password={{ galera_conf['dbusers']['xtrabackup']['password'] }} priv=*.*:"grant, reload, replication client"
+  mysql_user: user={{ galera_conf['dbusers']['xtrabackup']['username'] }} host="localhost" password={{ galera_conf['dbusers']['xtrabackup']['password'] }} priv=*.*:"grant,reload,replication client"
 
 - name: Add clustercheck database user (for clustercheck/xinetd -> haproxy) 
-  mysql_user: user={{ galera_conf['dbusers']['clustercheck']['username'] }} host="localhost" password={{ galera_conf['dbusers']['clustercheck']['password'] }} priv=*.*:"grant, reload, replication client"
+  mysql_user: user={{ galera_conf['dbusers']['clustercheck']['username'] }} host="localhost" password={{ galera_conf['dbusers']['clustercheck']['password'] }} priv=*.*:"grant,reload,replication client"
 


### PR DESCRIPTION
Fixes the error:

```
TASK: [CaptTofu.galera | Add xtrabackup database user (for Galera SST)] ******* 
failed: [test-mysql-cluster-1] => {"failed": true}
msg: invalid privileges string: Invalid privileges specified: frozenset([' RELOAD', ' REPLICATION CLIENT'])

FATAL: all hosts have already failed -- aborting
```

Notice the leading space.
