### PR TITLE
fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ How do I use this?
 
 Very simple. 
 
-1. ansible-galaxy install --force --roles-path=/where/ever/you/want/your/roles CaptTofu.ansible-galera 
+1. ansible-galaxy install --force --roles-path=/where/ever/you/want/your/roles CaptTofu.galera 
 
 2. Add three galera hosts to your ansible hosts file
 


### PR DESCRIPTION
```
$ ansible-galaxy -p ./roles install CaptTofu.ansible-galera
- downloading role 'ansible-galera', owned by CaptTofu
- sorry, CaptTofu.ansible-galera was not found on galaxy.ansible.com.
```
